### PR TITLE
Extract article metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "readable-readability"
 edition = "2021"
-version = "0.2.0"
+version = "0.3.0"
 description = "Really fast readability."
 keywords = ["dom", "html", "text", "extraction"]
 authors = ["Paul Loyd <pavelko95@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ url = "2.3.1"
 
 [dev-dependencies]
 env_logger = "0.9.3"
+serde = {version = "1.0", features = ["derive"]}
+serde_json = {version = "1.0", features = ["std"]}

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,6 +1,6 @@
 #![feature(test)]
 
-extern crate readability;
+extern crate readable_readability;
 extern crate url;
 
 extern crate test;
@@ -8,7 +8,7 @@ extern crate test;
 use test::Bencher;
 use url::Url;
 
-use readability::Readability;
+use readable_readability::Readability;
 
 
 macro_rules! include_sample_file {

--- a/samples/base_url/metadata.json
+++ b/samples/base_url/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Base URL test",
+    "article_title": "Lorem",
+    "byline": null,
+    "description": "Links"
+}

--- a/samples/bbc/metadata.json
+++ b/samples/bbc/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Obama admits US gun laws are his 'biggest frustration' - BBC News",
+    "article_title": "Obama admits US gun laws are his 'biggest frustration' - BBC News",
+    "byline": "BBC News",
+    "description": "President Barack Obama tells the BBC his failure to pass \"common sense gun safety laws\" is the greatest frustration of his presidency."
+}

--- a/samples/bbc/source.html
+++ b/samples/bbc/source.html
@@ -24,7 +24,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
     <title>Obama admits US gun laws are his 'biggest frustration' - BBC News</title>
-    <meta name="description" content="President Barack Obama tells the BBC his failure to pass " common="" sense="" gun="" safety="" laws"="" is="" the="" greatest="" frustration="" of="" his="" presidency."=""/>
+    <meta name="description" content="President Barack Obama tells the BBC his failure to pass &quot;common sense gun safety laws&quot; is the greatest frustration of his presidency."/>
 
     <meta name="x-country" content="us"/>
     <meta name="x-audience" content="US"/>

--- a/samples/buzzfeed/metadata.json
+++ b/samples/buzzfeed/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Student Dies After Diet Pills She Bought Online \"Burned Her Up From Within\" - BuzzFeed News",
+    "article_title": "Student Dies After Diet Pills She Bought Online \"Burned Her Up From Within\"",
+    "byline": "Mark Di Stefano",
+    "description": "An inquest into Eloise Parry's death has been adjourned until July..."
+}

--- a/samples/cnet/metadata.json
+++ b/samples/cnet/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Zuckerberg offers peek at Facebook's acquisition strategies - CNET",
+    "article_title": "Zuckerberg offers peek at Facebook's acquisition strategies",
+    "byline": null,
+    "description": "Facebook CEO says be a friend and have a shared vision, but scare them when you have to and move fast."
+}

--- a/samples/ehow_2/metadata.json
+++ b/samples/ehow_2/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "How to Throw a Graduation Party on a Budget (with Pictures) | eHow",
+    "article_title": "How to Throw a Graduation Party on a Budget | eHow",
+    "byline": "Gina Roberts-Grey",
+    "description": "How to Throw a Graduation Party on a Budget. Graduation parties are a great way to commemorate the years of hard work teens and college co-eds devote to education. They’re also costly for mom and dad.The average cost of a graduation party in 2013 was a whopping $1,200, according to Graduationparty.com; $700 of that was allocated for food...."
+}

--- a/samples/heise/metadata.json
+++ b/samples/heise/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "1Password für Mac generiert Einmal-Passwörter | Mac & i",
+    "article_title": "1Password für Mac generiert Einmal-Passwörter",
+    "byline": null,
+    "description": "Das in der iOS-Version bereits enthaltene TOTP-Feature ist nun auch für OS X 10.10 verfügbar. Zudem gibt es neue Zusatzfelder in der Datenbank und weitere Verbesserungen."
+}

--- a/samples/herald_sun/metadata.json
+++ b/samples/herald_sun/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Angry media won’t buckle over new surveillance laws\n\t\t\t\t\t\t| Herald Sun",
+    "article_title": "Angry media won’t buckle over new surveillance laws",
+    "byline": "Laurie Oakes",
+    "description": "A HIGH-powered federal government team has been doing the rounds of media organisations in the past few days in an attempt to allay concerns about the impact of new surveillance legislation on press freedom. It failed."
+}

--- a/samples/iab/metadata.json
+++ b/samples/iab/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Getting LEAN with Digital Ad UX | IAB",
+    "article_title": "Getting LEAN with Digital Ad UX | IAB",
+    "byline": null,
+    "description": "We messed up. As technologists, tasked with delivering content and services to users, we lost track of the user experience. Twenty years ago we saw an explosion of websites, built by developers around the world, providing all forms of content. This was the beginning of an age of enlightenment, the intersection of content and technology. … Continued"
+}

--- a/samples/libertation/metadata.json
+++ b/samples/libertation/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Un troisième Français mort dans le séisme au Népal - Libération",
+    "article_title": "Un troisième Français mort dans le séisme au Népal",
+    "byline": "http://www.liberation.fr/auteur/2005-afp",
+    "description": "\n  Laurent Fabius a accueilli jeudi matin à Roissy un premier avion spécial ramenant des rescapés.\n"
+}

--- a/samples/medium_1/metadata.json
+++ b/samples/medium_1/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "The Open Journalism Project: Better Student Journalism — Medium",
+    "article_title": "The Open Journalism Project: Better Student Journalism",
+    "byline": "Pippin Lee",
+    "description": "We pushed out the first version of the Open Journalism site in January. Here’s what we’ve learned about student journali…"
+}

--- a/samples/medium_2/metadata.json
+++ b/samples/medium_2/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "On Behalf of “Literally” — Medium",
+    "article_title": "On Behalf of “Literally”",
+    "byline": "Courtney Kirchoff",
+    "description": "In defense of the word “literally” and why you or someone you know should stop misusing the word, lest they drive us fig…"
+}

--- a/samples/mozilla_1/metadata.json
+++ b/samples/mozilla_1/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Firefox — Customize and make it your own — The most flexible browser on\n            the Web — Mozilla",
+    "article_title": "Firefox — Customize and make it your own — The most flexible browser on the Web",
+    "byline": null,
+    "description": ""
+}

--- a/samples/msn/metadata.json
+++ b/samples/msn/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Nintendo's first iPhone game will launch in December for $10",
+    "article_title": "Nintendo's first iPhone game will launch in December for $10",
+    "byline": null,
+    "description": "Nintendo and Apple shocked the world earlier this year by announcing \"Super Mario Run,\" the legendary gaming company's first foray into mobile gaming.&nbsp;"
+}

--- a/samples/nytimes_1/metadata.json
+++ b/samples/nytimes_1/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "United States to Lift Sudan Sanctions - The New York Times",
+    "article_title": "United States to Lift Sudan Sanctions",
+    "byline": "Jeffrey Gettleman",
+    "description": "For the first time since the 1990s, the country will be able to trade extensively with the United States."
+}

--- a/samples/replace_font_tags/metadata.json
+++ b/samples/replace_font_tags/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Replace font tags test",
+    "article_title": "Lorem",
+    "byline": null,
+    "description": null
+}

--- a/samples/social_buttons/metadata.json
+++ b/samples/social_buttons/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Share buttons removal test",
+    "article_title": "Lorem ipsum dolor",
+    "byline": null,
+    "description": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\n      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non\n      proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+}

--- a/samples/wikia/metadata.json
+++ b/samples/wikia/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "'Star Wars' Original Cuts Might Get Released for 40th Anniversary | Fandom powered by Wikia",
+    "article_title": "'Star Wars' Original Cuts Might Get Released for 40th Anniversary",
+    "byline": null,
+    "description": "As a 40th birthday present to the Star Wars Saga and its fans, Lucasfilm could re-release the original versions of the original trilogy films."
+}

--- a/samples/wikipedia/metadata.json
+++ b/samples/wikipedia/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Mozilla - Wikipedia",
+    "article_title": "Mozilla",
+    "byline": null,
+    "description": "Mozilla is a free-software community, created in 1998 by members of Netscape. The Mozilla community uses, develops, spreads and supports Mozilla products, thereby promoting exclusively free software and open standards, with only minor exceptions.[1] The community is supported institutionally by the Mozilla Foundation and its tax-paying subsidiary, the Mozilla Corporation.[2]"
+}

--- a/samples/wordpress/metadata.json
+++ b/samples/wordpress/metadata.json
@@ -1,0 +1,6 @@
+{
+    "page_title": "Stack Overflow Jobs Data Shows ReactJS Skills in High Demand, WordPress Market Oversaturated with Developers – WordPress Tavern",
+    "article_title": "Stack Overflow Jobs Data Shows ReactJS Skills in High Demand, WordPress Market Oversaturated with Developers",
+    "byline": null,
+    "description": "Stack Overflow published its analysis of 2017 hiring trends based on the targeting options employers selected when posting to Stack Overflow Jobs. The report, which compares data from 200 companies…"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use lazy_static::lazy_static;
 use log::trace;
 use url::Url;
 
+use metadata::Metadata;
 use node_cache::NodeCache;
 
 mod metadata;
@@ -456,8 +457,10 @@ impl Readability {
         self
     }
 
-    pub fn parse(&mut self, html: &str) -> NodeRef {
+    pub fn parse(&mut self, html: &str) -> (NodeRef, Metadata) {
         let top_level = kuchiki::parse_html().one(html);
+
+        let metadata = metadata::extract(&top_level);
 
         let top_level = top_level.select("html > body").unwrap().next()
             .map_or(top_level, |b| b.as_node().clone());
@@ -465,7 +468,7 @@ impl Readability {
         top_level.detach();
 
         // TODO: retry with fewer restrictions.
-        self.readify(top_level)
+        (self.readify(top_level), metadata)
     }
 
     fn readify(&mut self, top_level: NodeRef) -> NodeRef {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use lazy_static::lazy_static;
 use log::trace;
 use url::Url;
 
-use metadata::Metadata;
+pub use metadata::Metadata;
 use node_cache::NodeCache;
 
 mod metadata;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use url::Url;
 
 use node_cache::NodeCache;
 
+mod metadata;
 mod node_cache;
 
 // TODO: add examples.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,99 @@
+use html5ever::local_name;
+use kuchiki::NodeRef;
+
+
+const TITLE_CANDIDATES: [&str; 6] = [
+    "og:title", "twitter:title", "dc:title", "dcterm:title",
+    "weibo:article:title", "weibo:webpage:title", 
+];
+
+
+pub struct Metadata {
+    pub page_title: Option<String>,
+    pub article_title: Option<String>,
+    // pub byline: Option<String>,
+    // pub description: Option<String>,
+}
+
+
+pub fn extract(root: &NodeRef) -> Metadata {
+    let mut page_title = root.select_first("title")
+        .map(|node| Some(node.text_contents()))
+        .unwrap_or(None);
+
+    let mut article_title = find_article_title(root);
+
+    // if let (None, Some(at)) = (&page_title, &article_title) {
+    //     page_title = Some(at.clone());
+    // }
+    // if let(Some(pt), None) = (page_title, article_title) {
+    //     article_title = Some(pt.clone());
+    // }
+
+    match (&page_title, &article_title) {
+        (None, Some(at)) => {page_title = Some(at.clone());},
+        (Some(pt), None) => {article_title = Some(pt.clone());},
+        _ => (),
+    }
+
+    Metadata {page_title, article_title}
+}
+
+
+fn find_article_title(root: &NodeRef) -> Option<String> {
+    let meta_type_attrs = [
+        local_name!("name"),
+        local_name!("property"),
+        local_name!("itemprop"),
+    ];
+    // look for meta tags with `name`, `property`, or `itemprop` 
+    for meta in root.select("meta").unwrap() {
+        for attr in meta_type_attrs.iter() {
+            if let Some(type_name) = meta.attributes.borrow().get(attr) {
+                if TITLE_CANDIDATES.contains(&type_name) {
+                    if let Some(content) = meta.attributes.borrow().get(local_name!("content")) {
+                        return Some(content.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // if no qualifying meta tag is found, look for h1s
+    // only use an h1 as title if there are no others in the document
+    let mut h1s = root.select("h1").unwrap();
+    match (h1s.next(), h1s.next()) {
+        (Some(h), None) => return Some(h.text_contents()),
+        // we don't want to accept an h2 below if there are multiple h1s
+        (Some(_), Some(_)) => return None,
+        _ => (),
+    }
+
+    // same deal for h2's
+    let mut h2s = root.select("h2").unwrap();
+    match (h2s.next(), h2s.next()) {
+        (Some(h), None) => return Some(h.text_contents()),
+        _ => (),
+    }
+    None
+}
+
+
+use kuchiki::{parse_html, traits::TendrilSink};
+
+#[test]
+fn test_extract() {
+    const DOC: &str = 
+        "<!doctype html>
+        <head>
+            <title>Some Article - Some Site</title>
+            <meta name=\"og:title\" content=\"Some Article\">
+        </head>
+        <body>
+        </body>";
+
+    let root = kuchiki::parse_html().one(DOC);
+    let metadata = extract(&root);
+    assert_eq!(metadata.page_title, Some("Some Article - Some Site".into()));
+    assert_eq!(metadata.article_title, Some("Some Article".into()));
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,33 +2,33 @@ use html5ever::local_name;
 use kuchiki::NodeRef;
 
 
-const TITLE_CANDIDATES: [&str; 6] = [
+const TITLE_KEYS: [&str; 6] = [
     "og:title", "twitter:title", "dc:title", "dcterm:title",
-    "weibo:article:title", "weibo:webpage:title", 
+    "weibo:article:title", "weibo:webpage:title",
+];
+const BYLINE_KEYS: [&str; 4] = [
+    "author", "dc:creator", "dcterm:creator", "byl",
+];
+const DESCRIPTION_KEYS: [&str; 7] = [
+    "description", "og:description", "dc:description", "dcterm:description",
+    "weibo:article:description", "weibo:webpage:description", "twitter:description"
 ];
 
 
 pub struct Metadata {
     pub page_title: Option<String>,
     pub article_title: Option<String>,
-    // pub byline: Option<String>,
-    // pub description: Option<String>,
+    pub byline: Option<String>,
+    pub description: Option<String>,
 }
 
 
 pub fn extract(root: &NodeRef) -> Metadata {
     let mut page_title = root.select_first("title")
-        .map(|node| Some(node.text_contents()))
-        .unwrap_or(None);
+        .map(|node| node.text_contents())
+        .ok();
 
-    let mut article_title = find_article_title(root);
-
-    // if let (None, Some(at)) = (&page_title, &article_title) {
-    //     page_title = Some(at.clone());
-    // }
-    // if let(Some(pt), None) = (page_title, article_title) {
-    //     article_title = Some(pt.clone());
-    // }
+    let mut article_title = get_article_title(root);
 
     match (&page_title, &article_title) {
         (None, Some(at)) => {page_title = Some(at.clone());},
@@ -36,31 +36,20 @@ pub fn extract(root: &NodeRef) -> Metadata {
         _ => (),
     }
 
-    Metadata {page_title, article_title}
+    let byline = extract_meta_content(root, &BYLINE_KEYS);
+    let description = get_article_description(root);
+    Metadata {page_title, article_title, byline, description}
 }
 
 
-fn find_article_title(root: &NodeRef) -> Option<String> {
-    let meta_type_attrs = [
-        local_name!("name"),
-        local_name!("property"),
-        local_name!("itemprop"),
-    ];
-    // look for meta tags with `name`, `property`, or `itemprop` 
-    for meta in root.select("meta").unwrap() {
-        for attr in meta_type_attrs.iter() {
-            if let Some(type_name) = meta.attributes.borrow().get(attr) {
-                if TITLE_CANDIDATES.contains(&type_name) {
-                    if let Some(content) = meta.attributes.borrow().get(local_name!("content")) {
-                        return Some(content.to_string());
-                    }
-                }
-            }
-        }
+fn get_article_title(root: &NodeRef) -> Option<String> {
+    let meta_title = extract_meta_content(root, &TITLE_KEYS);
+    if meta_title.is_some() {
+        return meta_title;
     }
 
-    // if no qualifying meta tag is found, look for h1s
-    // only use an h1 as title if there are no others in the document
+    // if no qualifying meta tag is found, look for a single h1
+    // if there are multiple h1s, give up
     let mut h1s = root.select("h1").unwrap();
     match (h1s.next(), h1s.next()) {
         (Some(h), None) => return Some(h.text_contents()),
@@ -71,9 +60,46 @@ fn find_article_title(root: &NodeRef) -> Option<String> {
 
     // same deal for h2's
     let mut h2s = root.select("h2").unwrap();
-    match (h2s.next(), h2s.next()) {
-        (Some(h), None) => return Some(h.text_contents()),
-        _ => (),
+    if let (Some(h), None) = (h2s.next(), h2s.next()) {
+        return Some(h.text_contents())
+    }
+    None
+}
+
+
+fn get_article_description(root: &NodeRef) -> Option<String> {
+    let meta_desc = extract_meta_content(root, &DESCRIPTION_KEYS);
+    if meta_desc.is_some() {
+        return meta_desc;
+    }
+
+    // if the description isn't specified in a meta tag, use the text of the first <p>
+    root.select_first("p")
+        .map(|p| p.text_contents())
+        .ok()
+}
+
+
+// Given a root node and a list of meta keys, return the content of the first meta tag
+// with its `name`, `property`, or `itemprop` attribute set to one of the expected types.
+fn extract_meta_content(root: &NodeRef, expected_types: &[&str]) -> Option<String> {
+    let meta_type_attrs = [
+        local_name!("name"),
+        local_name!("property"),
+        local_name!("itemprop"),
+    ];
+    // unwrap is safe here because select() only errors when you give it an invalid CSS selector
+    for meta_node in root.select("meta").unwrap() {
+        for attr_name in &meta_type_attrs {
+            let attributes = meta_node.attributes.borrow();
+            if let Some(meta_type) = attributes.get(attr_name) {
+                if expected_types.contains(&meta_type) {
+                    if let Some(content) = attributes.get(local_name!("content")) {
+                        return Some(content.to_string());
+                    }
+                }
+            }
+        }
     }
     None
 }
@@ -88,6 +114,8 @@ fn test_extract() {
         <head>
             <title>Some Article - Some Site</title>
             <meta name=\"og:title\" content=\"Some Article\">
+            <meta property=\"author\" content=\"Joe Schmoe\">
+            <meta itemprop=\"dcterm:description\" content=\"A test article for test cases.\">
         </head>
         <body>
         </body>";

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -6,11 +6,12 @@ const TITLE_KEYS: [&str; 6] = [
     "og:title", "twitter:title", "dc:title", "dcterm:title",
     "weibo:article:title", "weibo:webpage:title",
 ];
-const BYLINE_KEYS: [&str; 4] = [
-    "author", "dc:creator", "dcterm:creator", "byl",
+const BYLINE_KEYS: [&str; 6] = [
+    "author", "dc:creator", "dcterm:creator", "og:article:author",
+    "article:author", "byl",
 ];
 const DESCRIPTION_KEYS: [&str; 7] = [
-    "description", "og:description", "dc:description", "dcterm:description",
+    "description", "dc:description", "dcterm:description", "og:description",
     "weibo:article:description", "weibo:webpage:description", "twitter:description"
 ];
 
@@ -105,6 +106,7 @@ fn extract_meta_content(root: &NodeRef, expected_types: &[&str]) -> Option<Strin
 }
 
 
+#[allow(unused_imports)]
 use kuchiki::{parse_html, traits::TendrilSink};
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -109,14 +109,14 @@ macro_rules! test_sample {
 
             setup_logger();
 
-            let actual = Readability::new()
+            let (actual_tree, meta) = Readability::new()
                 .base_url(Url::parse("http://fakehost/test/page.html").unwrap())
                 .parse(SOURCE);
 
-            let expected = kuchiki::parse_html().one(EXPECTED)
+            let expected_tree = kuchiki::parse_html().one(EXPECTED)
                 .select("body > *").unwrap().next().unwrap().as_node().clone();
 
-            compare_trees(&actual, &expected);
+            compare_trees(&actual_tree, &expected_tree);
         }
     };
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,9 +3,28 @@ use std::io::Write;
 use kuchiki::NodeRef;
 use kuchiki::NodeData::*;
 use kuchiki::traits::TendrilSink;
+use serde::Deserialize;
 use url::Url;
 
-use readable_readability::Readability;
+use readable_readability::{Readability, Metadata};
+
+
+// duplicate the Metadata struct so we can implement Deserialize
+#[derive(Deserialize)]
+struct TestMetadata {
+    pub page_title: Option<String>,
+    pub article_title: Option<String>,
+    pub byline: Option<String>,
+    pub description: Option<String>,
+}
+
+
+fn compare_metadata(actual: &Metadata, expected: &TestMetadata) {
+    assert_eq!(actual.page_title, expected.page_title);
+    assert_eq!(actual.article_title, expected.article_title);
+    assert_eq!(actual.byline, expected.byline);
+    assert_eq!(actual.description, expected.description);
+}
 
 
 fn compare_trees(actual: &NodeRef, expected: &NodeRef) {
@@ -106,10 +125,11 @@ macro_rules! test_sample {
         fn $name() {
             static SOURCE: &'static str = include_sample_file!($name, "source.html");
             static EXPECTED: &'static str = include_sample_file!($name, "expected.html");
+            static EXPECTED_META: &'static str = include_sample_file!($name, "metadata.json");
 
             setup_logger();
 
-            let (actual_tree, meta) = Readability::new()
+            let (actual_tree, actual_meta) = Readability::new()
                 .base_url(Url::parse("http://fakehost/test/page.html").unwrap())
                 .parse(SOURCE);
 
@@ -117,6 +137,9 @@ macro_rules! test_sample {
                 .select("body > *").unwrap().next().unwrap().as_node().clone();
 
             compare_trees(&actual_tree, &expected_tree);
+
+            let expected_meta = serde_json::from_str(EXPECTED_META).unwrap();
+            compare_metadata(&actual_meta, &expected_meta);
         }
     };
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,7 +5,7 @@ use kuchiki::NodeData::*;
 use kuchiki::traits::TendrilSink;
 use url::Url;
 
-use readability::Readability;
+use readable_readability::Readability;
 
 
 fn compare_trees(actual: &NodeRef, expected: &NodeRef) {


### PR DESCRIPTION
Adds metadata extraction. 

I decided to split the page title (contents of the `<title>` element) apart from the "article title" (content of a matching meta tag, or of a h1/h2 if it's the only one on the page) because these are often different. For example, a lot of sites append or prepend the site name to the HTML `<title>`, and I don't think we want that showing up in the page header. 

If it finds one but not the other, it will return the same value for both.

@mre You mentioned you'd like the title to be passed through unmodified, rather than being altered during extraction. Unfortunately it seems that calling `NodeRef::text_contents()` automatically unescapes HTML entities, e.g. `&quot;` becomes `"`. Do you want me to see if I can find a way around that, or were you thinking of other modifications?