### PR TITLE
Update kuchiki

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ regex = "1.6.0"
 url = "2.3.1"
 
 [dev-dependencies]
-env_logger = "0.9.3"
+env_logger = "0.11.3"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0", features = ["std"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 
 [dependencies]
 log = "0.4.17"
-kuchiki = "0.8.1"
-html5ever = "0.25.2"
+kuchikiki = "0.8.1"
+html5ever = "0.26.0"
 lazy_static = "1.4.0"
 regex = "1.6.0"
 url = "2.3.1"

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -10,11 +10,10 @@ use url::Url;
 
 use readable_readability::Readability;
 
-
 macro_rules! include_sample_file {
     ($name:ident, $file:expr) => {
         include_str!(concat!("../samples/", stringify!($name), "/", $file))
-    }
+    };
 }
 
 macro_rules! bench_sample {
@@ -23,10 +22,11 @@ macro_rules! bench_sample {
         fn $name(b: &mut Bencher) {
             static SOURCE: &'static str = include_sample_file!($name, "source.html");
 
-            b.iter(||
+            b.iter(|| {
                 Readability::new()
                     .base_url(Url::parse("http://fakehost/test/page.html").unwrap())
-                    .parse(SOURCE));
+                    .parse(SOURCE)
+            });
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 use std::cmp;
-use std::iter;
 use std::f32;
 use std::fmt;
+use std::iter;
 
-use regex::Regex;
-use html5ever::{QualName, local_name, namespace_url, ns};
-use kuchiki::{NodeRef, NodeDataRef, NodeData, ElementData, Attributes};
-use kuchiki::traits::TendrilSink;
+use html5ever::{local_name, namespace_url, ns, QualName};
 use kuchiki::iter::NodeIterator;
+use kuchiki::traits::TendrilSink;
+use kuchiki::{Attributes, ElementData, NodeData, NodeDataRef, NodeRef};
 use lazy_static::lazy_static;
 use log::trace;
+use regex::Regex;
 use url::Url;
 
 pub use metadata::Metadata;
@@ -27,7 +27,9 @@ trait NodeRefExt {
     fn node_ref(&self) -> &NodeRef;
 
     fn is(&self, name: QualName) -> bool {
-        self.node_ref().as_element().map_or(false, |e| e.name == name)
+        self.node_ref()
+            .as_element()
+            .map_or(false, |e| e.name == name)
     }
 
     fn replace<N: NodeRefExt>(&self, node: &N) {
@@ -43,7 +45,7 @@ trait NodeRefExt {
         let node = self.node_ref();
 
         if let Some(elem) = node.as_element() {
-            // I'd like find a way to do this without clone(), but 
+            // I'd like find a way to do this without clone(), but
             // I'm not sure how because BTreeMap doesn't have drain()
             let attributes = elem.attributes.borrow();
             let replacement = NodeRef::new_element(name, attributes.map.clone());
@@ -117,7 +119,7 @@ lazy_static! {
 }
 
 macro_rules! tag {
-    ($name:tt) => { 
+    ($name:tt) => {
         QualName {
             prefix: None,
             ns: ns!(html),
@@ -127,7 +129,9 @@ macro_rules! tag {
 }
 
 macro_rules! attrib {
-    ($name:tt) => { local_name!($name) };
+    ($name:tt) => {
+        local_name!($name)
+    };
 }
 
 fn extract_byline(elem: &ElemRef) -> Option<String> {
@@ -169,8 +173,8 @@ fn is_unlikely_candidate(elem: &ElemRef) -> bool {
     let classes = attributes.get(attrib!("class")).unwrap_or("");
     let id = attributes.get(attrib!("id")).unwrap_or("");
 
-    (UNLIKELY_CANDIDATE.is_match(classes) || UNLIKELY_CANDIDATE.is_match(id)) &&
-        !(MAYBE_CANDIDATE.is_match(classes) || MAYBE_CANDIDATE.is_match(id))
+    (UNLIKELY_CANDIDATE.is_match(classes) || UNLIKELY_CANDIDATE.is_match(id))
+        && !(MAYBE_CANDIDATE.is_match(classes) || MAYBE_CANDIDATE.is_match(id))
 }
 
 fn transform_div(div: &ElemRef) {
@@ -217,14 +221,18 @@ fn has_single_p(node: &NodeRef) -> bool {
         return false;
     }
 
-    node.children().text_nodes().all(|t| t.borrow().trim().is_empty())
+    node.children()
+        .text_nodes()
+        .all(|t| t.borrow().trim().is_empty())
 }
 
 fn has_block_elem(node: &NodeRef) -> bool {
-    node.descendants().elements().any(|elem| matches!{
-        elem.name,
-        tag!("a") | tag!("blockquote") | tag!("dl") | tag!("div") | tag!("img") | tag!("ol") |
-        tag!("p") | tag!("pre") | tag!("table") | tag!("ul") | tag!("select")
+    node.descendants().elements().any(|elem| {
+        matches! {
+            elem.name,
+            tag!("a") | tag!("blockquote") | tag!("dl") | tag!("div") | tag!("img") | tag!("ol") |
+            tag!("p") | tag!("pre") | tag!("table") | tag!("ul") | tag!("select")
+        }
     })
 }
 
@@ -254,7 +262,7 @@ fn count_chars(text: &str) -> (u32, u32) {
 }
 
 fn is_tag_to_score(tag: &QualName) -> bool {
-    matches!{
+    matches! {
         *tag,
         tag!("section") | tag!("p") | tag!("td") | tag!("pre") |
         tag!("h2") | tag!("h3") | tag!("h4") | tag!("h5") | tag!("h6")
@@ -272,7 +280,7 @@ fn tag_score(tag: &QualName) -> f32 {
         tag!("body") => -5.,
         tag!("h1") | tag!("h2") | tag!("h3") | tag!("h4") | tag!("h5") | tag!("h6") => -5.,
         tag!("th") => -5.,
-        _ => 0.
+        _ => 0.,
     }
 }
 
@@ -281,13 +289,21 @@ fn class_score(elem: &ElemRef) -> f32 {
     let mut score = 0.;
 
     if let Some(classes) = attributes.get(attrib!("class")) {
-        if POSITIVE.is_match(classes) { score += 25.; }
-        if NEGATIVE.is_match(classes) { score -= 25.; }
+        if POSITIVE.is_match(classes) {
+            score += 25.;
+        }
+        if NEGATIVE.is_match(classes) {
+            score -= 25.;
+        }
     }
 
     if let Some(id) = attributes.get(attrib!("id")) {
-        if POSITIVE.is_match(id) { score += 25.; }
-        if NEGATIVE.is_match(id) { score -= 25.; }
+        if POSITIVE.is_match(id) {
+            score += 25.;
+        }
+        if NEGATIVE.is_match(id) {
+            score -= 25.;
+        }
     }
 
     score
@@ -298,8 +314,14 @@ fn is_stuffed(elem: &ElemRef, info: &NodeInfo) -> bool {
         // TODO: remove <object>, <embed> etc.
         tag!("h1") | tag!("footer") | tag!("button") => false,
 
-        tag!("div") | tag!("section") | tag!("header") |
-        tag!("h2") | tag!("h3") | tag!("h4") | tag!("h5") | tag!("h6") => {
+        tag!("div")
+        | tag!("section")
+        | tag!("header")
+        | tag!("h2")
+        | tag!("h3")
+        | tag!("h4")
+        | tag!("h5")
+        | tag!("h6") => {
             if info.text_len == 0 {
                 let children_count = elem.as_node().children().count() as u32;
 
@@ -309,19 +331,23 @@ fn is_stuffed(elem: &ElemRef, info: &NodeInfo) -> bool {
             }
 
             true
-        },
+        }
 
         tag!("thead") | tag!("tbody") | tag!("th") | tag!("tr") | tag!("td") =>
-            // TODO: add <video> and <audio> counters to the sum.
-            info.text_len > 0 || info.img_count + info.embed_count + info.iframe_count > 0,
+        // TODO: add <video> and <audio> counters to the sum.
+        {
+            info.text_len > 0 || info.img_count + info.embed_count + info.iframe_count > 0
+        }
 
         tag!("p") | tag!("pre") | tag!("blockquote") =>
-            // TODO: add <video> and <audio> counters to the sum.
+        // TODO: add <video> and <audio> counters to the sum.
+        {
             info.img_count + info.embed_count + info.iframe_count > 0 ||
             // TODO: calculate length without construction the string.
-                !elem.text_contents().trim().is_empty(),
+                !elem.text_contents().trim().is_empty()
+        }
 
-        _ => true
+        _ => true,
     }
 }
 
@@ -352,7 +378,10 @@ fn fix_relative_urls(attributes: &mut Attributes, base_url: &Url) {
 }
 
 fn is_acceptable_top_level(tag: &QualName) -> bool {
-    matches!(*tag, tag!("div") | tag!("article") | tag!("section") | tag!("p"))
+    matches!(
+        *tag,
+        tag!("div") | tag!("article") | tag!("section") | tag!("p")
+    )
 }
 
 #[derive(Default, PartialEq, Clone)]
@@ -378,20 +407,48 @@ impl fmt::Debug for NodeInfo {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let mut s = fmt.debug_struct("");
 
-        if self.content_score > 0. { s.field("content_score", &self.content_score); }
-        if self.text_len > 0 { s.field("text", &self.text_len); }
-        if self.link_len > 0 { s.field("link", &self.link_len); }
-        if self.commas > 0 { s.field("commas", &self.commas); }
-        if self.is_candidate { s.field("candidate", &self.is_candidate); }
-        if self.is_shabby { s.field("shabby", &self.is_shabby); }
-        if self.p_count > 0 { s.field("p", &self.p_count); }
-        if self.img_count > 0 { s.field("img", &self.img_count); }
-        if self.li_count > 0 { s.field("li", &self.li_count); }
-        if self.input_count > 0 { s.field("input", &self.input_count); }
-        if self.embed_count > 0 { s.field("embed", &self.embed_count); }
-        if self.iframe_count > 0 { s.field("iframe", &self.iframe_count); }
-        if self.br_count > 0 { s.field("br", &self.br_count); }
-        if self.hr_count > 0 { s.field("hr", &self.hr_count); }
+        if self.content_score > 0. {
+            s.field("content_score", &self.content_score);
+        }
+        if self.text_len > 0 {
+            s.field("text", &self.text_len);
+        }
+        if self.link_len > 0 {
+            s.field("link", &self.link_len);
+        }
+        if self.commas > 0 {
+            s.field("commas", &self.commas);
+        }
+        if self.is_candidate {
+            s.field("candidate", &self.is_candidate);
+        }
+        if self.is_shabby {
+            s.field("shabby", &self.is_shabby);
+        }
+        if self.p_count > 0 {
+            s.field("p", &self.p_count);
+        }
+        if self.img_count > 0 {
+            s.field("img", &self.img_count);
+        }
+        if self.li_count > 0 {
+            s.field("li", &self.li_count);
+        }
+        if self.input_count > 0 {
+            s.field("input", &self.input_count);
+        }
+        if self.embed_count > 0 {
+            s.field("embed", &self.embed_count);
+        }
+        if self.iframe_count > 0 {
+            s.field("iframe", &self.iframe_count);
+        }
+        if self.br_count > 0 {
+            s.field("br", &self.br_count);
+        }
+        if self.hr_count > 0 {
+            s.field("hr", &self.hr_count);
+        }
 
         s.finish()
     }
@@ -406,7 +463,7 @@ pub struct Readability {
     weight_classes: bool,
     clean_conditionally: bool,
     clean_attributes: bool,
-    base_url: Option<Url>
+    base_url: Option<Url>,
 }
 
 impl Default for Readability {
@@ -451,7 +508,8 @@ impl Readability {
     }
 
     pub fn base_url<U>(&mut self, url: U) -> &mut Self
-        where U: Into<Option<Url>>
+    where
+        U: Into<Option<Url>>,
     {
         self.base_url = url.into();
         self
@@ -462,7 +520,10 @@ impl Readability {
 
         let metadata = metadata::extract(&top_level);
 
-        let top_level = top_level.select("html > body").unwrap().next()
+        let top_level = top_level
+            .select("html > body")
+            .unwrap()
+            .next()
             .map_or(top_level, |b| b.as_node().clone());
 
         top_level.detach();
@@ -494,11 +555,15 @@ impl Readability {
             } else if let Some(parent) = current.parent() {
                 (parent, bubbling)
             } else {
-                if bubbling { self.on_bubbling(&current); }
+                if bubbling {
+                    self.on_bubbling(&current);
+                }
                 break;
             };
 
-            if bubbling { self.on_bubbling(&current); }
+            if bubbling {
+                self.on_bubbling(&current);
+            }
 
             bubbling = nbubbling;
             current = ncurrent;
@@ -532,13 +597,16 @@ impl Readability {
                 NodeData::Text(ref data) => data.borrow().trim().is_empty(),
                 NodeData::Element(ref elem) => {
                     matches!(elem.name, tag!("script") | tag!("style") | tag!("noscript"))
-                },
-                _ => false
+                }
+                _ => false,
             };
 
             if remove {
                 if child.as_element().is_some() {
-                    trace!("    => removing <{}> as useless element", format_tag(&child));
+                    trace!(
+                        "    => removing <{}> as useless element",
+                        format_tag(&child)
+                    );
                 }
 
                 child.remove();
@@ -547,17 +615,23 @@ impl Readability {
             if let Some(child) = child.into_element_ref() {
                 // TODO: mozilla/readability takes into account only first occurrence.
                 //if self.byline.is_none() {
-                    if let Some(byline) = extract_byline(&child) {
-                        self.byline = Some(byline);
-                        trace!("    => removing <{}> as byline container", format_tag(&child));
-                        child.remove();
+                if let Some(byline) = extract_byline(&child) {
+                    self.byline = Some(byline);
+                    trace!(
+                        "    => removing <{}> as byline container",
+                        format_tag(&child)
+                    );
+                    child.remove();
 
-                        continue;
-                    }
+                    continue;
+                }
                 //}
 
                 if self.strip_unlikelys && is_unlikely_candidate(&child) {
-                    trace!("    => removing <{}> as unlikely candidate", format_tag(&child));
+                    trace!(
+                        "    => removing <{}> as unlikely candidate",
+                        format_tag(&child)
+                    );
                     child.remove();
                 } else if child.is(tag!("div")) {
                     transform_div(&child);
@@ -580,9 +654,17 @@ impl Readability {
                 let parent_info = self.info.get_or_create(&parent);
                 parent_info.text_len += char_cnt;
                 parent_info.commas += comma_cnt;
-            },
-            NodeData::Element(ElementData { ref name, ref attributes, .. }) => {
-                trace!("</{}> {}", format_tag(node), format_info(self.info.get(node)));
+            }
+            NodeData::Element(ElementData {
+                ref name,
+                ref attributes,
+                ..
+            }) => {
+                trace!(
+                    "</{}> {}",
+                    format_tag(node),
+                    format_info(self.info.get(node))
+                );
 
                 // FIXME: don't propagate info of bad nodes.
                 self.propagate_info(node);
@@ -606,7 +688,8 @@ impl Readability {
                         info.is_candidate = false;
                     }
 
-                    if let Some(info) = node.parent().map(|parent| self.info.get_or_create(&parent)) {
+                    if let Some(info) = node.parent().map(|parent| self.info.get_or_create(&parent))
+                    {
                         info.is_shabby = true;
                     }
 
@@ -636,7 +719,7 @@ impl Readability {
                         fix_relative_urls(&mut attributes, base_url);
                     }
                 }
-            },
+            }
             _ => {}
         };
     }
@@ -644,7 +727,7 @@ impl Readability {
     fn propagate_info(&mut self, node: &NodeRef) {
         let parent = match node.parent() {
             Some(parent) => parent,
-            None => return
+            None => return,
         };
 
         let is_a = node.is(tag!("a"));
@@ -669,7 +752,7 @@ impl Readability {
                     if !VIDEO.is_match(src) {
                         parent_info.embed_count += 1;
                     }
-                },
+                }
                 _ => {}
             };
         }
@@ -691,11 +774,15 @@ impl Readability {
         let is_list = match elem.name {
             tag!("form") | tag!("fieldset") | tag!("table") | tag!("div") => false,
             tag!("ul") | tag!("ol") => true,
-            _ => return true
+            _ => return true,
         };
 
         // TODO: cache the score to prevent extra calculations.
-        let class_score = if self.weight_classes { class_score(elem) } else { 0. };
+        let class_score = if self.weight_classes {
+            class_score(elem)
+        } else {
+            0.
+        };
 
         if class_score < 0. {
             return false;
@@ -711,15 +798,13 @@ impl Readability {
         let p_img_ratio = info.p_count as f32 / info.img_count as f32;
 
         // TODO: take into account ancestor tags (check "figure").
-        !(
-            (info.img_count > 1 && p_img_ratio < 0.5) ||
-            (!is_list && info.li_count > info.p_count + 100) ||
-            (info.input_count * 3 > info.p_count) ||
-            (!is_list && info.text_len < 25 && (info.img_count == 0 || info.img_count > 2)) ||
-            (!is_list && class_score < 25. && link_density > 0.2) ||
-            (class_score >= 25. && link_density > 0.5) ||
-            ((info.embed_count == 1 && info.text_len < 75) || info.embed_count > 1)
-         )
+        !((info.img_count > 1 && p_img_ratio < 0.5)
+            || (!is_list && info.li_count > info.p_count + 100)
+            || (info.input_count * 3 > info.p_count)
+            || (!is_list && info.text_len < 25 && (info.img_count == 0 || info.img_count > 2))
+            || (!is_list && class_score < 25. && link_density > 0.2)
+            || (class_score >= 25. && link_density > 0.5)
+            || ((info.embed_count == 1 && info.text_len < 75) || info.embed_count > 1))
     }
 
     fn score_node(&mut self, node: &NodeRef) {
@@ -760,7 +845,7 @@ impl Readability {
             let div = match level {
                 0 => 1.,
                 1 => 2.,
-                _ => 3. * level as f32
+                _ => 3. * level as f32,
             };
 
             let addition = content_score / div;
@@ -782,8 +867,11 @@ impl Readability {
         let mut scored_candidates = Vec::with_capacity(self.candidates.len());
 
         for candidate in self.candidates.drain(..) {
-            trace!("Candidate: <{}> {}",
-                   format_tag(&candidate), format_info(self.info.get(candidate.as_node())));
+            trace!(
+                "Candidate: <{}> {}",
+                format_tag(&candidate),
+                format_info(self.info.get(candidate.as_node()))
+            );
 
             let info = self.info.get(candidate.as_node()).unwrap();
 
@@ -827,7 +915,8 @@ impl Readability {
 
         let score_threshold = scored_candidates[0].0 * 0.75;
 
-        let top_candidate_it = scored_candidates.into_iter()
+        let top_candidate_it = scored_candidates
+            .into_iter()
             .take_while(|&(score, _)| score >= score_threshold)
             .map(|(_, candidate)| candidate);
 
@@ -844,8 +933,10 @@ impl Readability {
 
         let best = self.candidates[0].as_node();
 
-        if self.candidates.len() < MIN_CANDIDATES ||
-           best.is(tag!("body")) || best.parent().map_or(true, |p| p.is(tag!("body"))) {
+        if self.candidates.len() < MIN_CANDIDATES
+            || best.is(tag!("body"))
+            || best.parent().map_or(true, |p| p.is(tag!("body")))
+        {
             return best.clone();
         }
 
@@ -858,7 +949,10 @@ impl Readability {
                 }
 
                 if n == MIN_CANDIDATES {
-                    trace!("Found common parent of top candidates: <{}>", format_tag(&common));
+                    trace!(
+                        "Found common parent of top candidates: <{}>",
+                        format_tag(&common)
+                    );
                     return common;
                 }
             }
@@ -896,8 +990,10 @@ impl Readability {
         let parent_it = candidate.ancestors().take_while(|parent| {
             let mut child_it = parent.children();
 
-            !parent.is(tag!("body")) && child_it.next().is_some() && child_it.next().is_none() &&
-                self.info.get(parent).map_or(true, |info| !info.is_shabby)
+            !parent.is(tag!("body"))
+                && child_it.next().is_some()
+                && child_it.next().is_none()
+                && self.info.get(parent).map_or(true, |info| !info.is_shabby)
         });
 
         let result = parent_it.last().map_or(candidate, |parent| {
@@ -923,7 +1019,7 @@ fn format_tag<N: NodeRefExt>(node: &N) -> String {
         (Some(id), Some(class)) => format!("{} id=\"{}\" class=\"{}\"", tag, id, class),
         (Some(id), None) => format!("{} id=\"{}\"", tag, id),
         (None, Some(class)) => format!("{} class=\"{}\"", tag, class),
-        (None, None) => format!("{}", tag)
+        (None, None) => format!("{}", tag),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,9 @@ use std::fmt;
 use std::iter;
 
 use html5ever::{local_name, namespace_url, ns, QualName};
-use kuchiki::iter::NodeIterator;
-use kuchiki::traits::TendrilSink;
-use kuchiki::{Attributes, ElementData, NodeData, NodeDataRef, NodeRef};
+use kuchikiki::iter::NodeIterator;
+use kuchikiki::traits::TendrilSink;
+use kuchikiki::{Attributes, ElementData, NodeData, NodeDataRef, NodeRef};
 use lazy_static::lazy_static;
 use log::trace;
 use regex::Regex;
@@ -516,7 +516,7 @@ impl Readability {
     }
 
     pub fn parse(&mut self, html: &str) -> (NodeRef, Metadata) {
-        let top_level = kuchiki::parse_html().one(html);
+        let top_level = kuchikiki::parse_html().one(html);
 
         let metadata = metadata::extract(&top_level);
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,5 +1,5 @@
 use html5ever::local_name;
-use kuchiki::NodeRef;
+use kuchikiki::NodeRef;
 
 const TITLE_KEYS: [&str; 6] = [
     "og:title",
@@ -127,7 +127,7 @@ fn extract_meta_content(root: &NodeRef, expected_types: &[&str]) -> Option<Strin
 mod tests {
     #![cfg(test)]
     use super::*;
-    use kuchiki::traits::TendrilSink;
+    use kuchikiki::traits::TendrilSink;
 
     #[test]
     fn test_extract() {
@@ -142,7 +142,7 @@ mod tests {
             <body>
             </body>";
 
-        let root = kuchiki::parse_html().one(DOC);
+        let root = kuchikiki::parse_html().one(DOC);
         let metadata = extract(&root);
         assert_eq!(metadata.page_title, Some("Some Article - Some Site".into()));
         assert_eq!(metadata.article_title, Some("Some Article".into()));

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,23 +1,32 @@
 use html5ever::local_name;
 use kuchiki::NodeRef;
 
-
 const TITLE_KEYS: [&str; 6] = [
-    "og:title", "twitter:title", "dc:title", "dcterm:title",
-    "weibo:article:title", "weibo:webpage:title",
+    "og:title",
+    "twitter:title",
+    "dc:title",
+    "dcterm:title",
+    "weibo:article:title",
+    "weibo:webpage:title",
 ];
 const BYLINE_KEYS: [&str; 6] = [
-    "author", "dc:creator", "dcterm:creator", "og:article:author",
-    "article:author", "byl",
+    "author",
+    "dc:creator",
+    "dcterm:creator",
+    "og:article:author",
+    "article:author",
+    "byl",
 ];
 const DESCRIPTION_KEYS: [&str; 7] = [
-    "description", "dc:description", "dcterm:description", "og:description",
-    "weibo:article:description", "weibo:webpage:description", "twitter:description"
+    "description",
+    "dc:description",
+    "dcterm:description",
+    "og:description",
+    "weibo:article:description",
+    "weibo:webpage:description",
+    "twitter:description",
 ];
-const IMAGE_KEYS: [&str; 3] = [
-    "og:image", "og:image:url", "twitter:image",
-];
-
+const IMAGE_KEYS: [&str; 3] = ["og:image", "og:image:url", "twitter:image"];
 
 pub struct Metadata {
     pub page_title: Option<String>,
@@ -27,26 +36,35 @@ pub struct Metadata {
     pub description: Option<String>,
 }
 
-
 pub fn extract(root: &NodeRef) -> Metadata {
-    let mut page_title = root.select_first("title")
+    let mut page_title = root
+        .select_first("title")
         .map(|node| node.text_contents())
         .ok();
 
     let mut article_title = get_article_title(root);
 
     match (&page_title, &article_title) {
-        (None, Some(at)) => {page_title = Some(at.clone());},
-        (Some(pt), None) => {article_title = Some(pt.clone());},
+        (None, Some(at)) => {
+            page_title = Some(at.clone());
+        }
+        (Some(pt), None) => {
+            article_title = Some(pt.clone());
+        }
         _ => (),
     }
 
     let image_url = extract_meta_content(root, &IMAGE_KEYS);
     let byline = extract_meta_content(root, &BYLINE_KEYS);
     let description = get_article_description(root);
-    Metadata {page_title, article_title, image_url, byline, description}
+    Metadata {
+        page_title,
+        article_title,
+        image_url,
+        byline,
+        description,
+    }
 }
-
 
 fn get_article_title(root: &NodeRef) -> Option<String> {
     let meta_title = extract_meta_content(root, &TITLE_KEYS);
@@ -67,11 +85,10 @@ fn get_article_title(root: &NodeRef) -> Option<String> {
     // same deal for h2's
     let mut h2s = root.select("h2").unwrap();
     if let (Some(h), None) = (h2s.next(), h2s.next()) {
-        return Some(h.text_contents())
+        return Some(h.text_contents());
     }
     None
 }
-
 
 fn get_article_description(root: &NodeRef) -> Option<String> {
     let meta_desc = extract_meta_content(root, &DESCRIPTION_KEYS);
@@ -80,11 +97,8 @@ fn get_article_description(root: &NodeRef) -> Option<String> {
     }
 
     // if the description isn't specified in a meta tag, use the text of the first <p>
-    root.select_first("p")
-        .map(|p| p.text_contents())
-        .ok()
+    root.select_first("p").map(|p| p.text_contents()).ok()
 }
-
 
 // Given a root node and a list of meta keys, return the content of the first meta tag
 // with its `name`, `property`, or `itemprop` attribute set to one of the expected types.
@@ -110,16 +124,14 @@ fn extract_meta_content(root: &NodeRef, expected_types: &[&str]) -> Option<Strin
     None
 }
 
-
 mod tests {
     #![cfg(test)]
     use super::*;
-    use kuchiki::{parse_html, traits::TendrilSink};
+    use kuchiki::traits::TendrilSink;
 
     #[test]
     fn test_extract() {
-        const DOC: &str = 
-            "<!doctype html>
+        const DOC: &str = "<!doctype html>
             <head>
                 <title>Some Article - Some Site</title>
                 <meta name=\"og:title\" content=\"Some Article\">
@@ -134,8 +146,14 @@ mod tests {
         let metadata = extract(&root);
         assert_eq!(metadata.page_title, Some("Some Article - Some Site".into()));
         assert_eq!(metadata.article_title, Some("Some Article".into()));
-        assert_eq!(metadata.image_url, Some("https://somesite.com/image.png".into()));
+        assert_eq!(
+            metadata.image_url,
+            Some("https://somesite.com/image.png".into())
+        );
         assert_eq!(metadata.byline, Some("Joe Schmoe".into()));
-        assert_eq!(metadata.description, Some("A test article for test cases.".into()));
+        assert_eq!(
+            metadata.description,
+            Some("A test article for test cases.".into())
+        );
     }
 }

--- a/src/node_cache.rs
+++ b/src/node_cache.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
-use kuchiki::{Node, NodeRef};
+use kuchikiki::{Node, NodeRef};
 
 struct HashableNodeRef(NodeRef);
 

--- a/src/node_cache.rs
+++ b/src/node_cache.rs
@@ -3,7 +3,6 @@ use std::hash::{Hash, Hasher};
 
 use kuchiki::{Node, NodeRef};
 
-
 struct HashableNodeRef(NodeRef);
 
 impl PartialEq for HashableNodeRef {
@@ -36,6 +35,6 @@ impl<T: Default> NodeCache<T> {
 
     pub fn get_or_create(&mut self, node: &NodeRef) -> &mut T {
         let key = HashableNodeRef(node.clone());
-        self.0.entry(key).or_insert_with(Default::default)
+        self.0.entry(key).or_default()
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
-use kuchiki::traits::TendrilSink;
-use kuchiki::NodeData::*;
-use kuchiki::NodeRef;
+use kuchikiki::traits::TendrilSink;
+use kuchikiki::NodeData::*;
+use kuchikiki::NodeRef;
 use serde::Deserialize;
 use url::Url;
 
@@ -140,7 +140,7 @@ macro_rules! test_sample {
                 .base_url(Url::parse("http://fakehost/test/page.html").unwrap())
                 .parse(SOURCE);
 
-            let expected_tree = kuchiki::parse_html()
+            let expected_tree = kuchikiki::parse_html()
                 .one(EXPECTED)
                 .select("body > *")
                 .unwrap()

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,13 +1,12 @@
 use std::io::Write;
 
-use kuchiki::NodeRef;
-use kuchiki::NodeData::*;
 use kuchiki::traits::TendrilSink;
+use kuchiki::NodeData::*;
+use kuchiki::NodeRef;
 use serde::Deserialize;
 use url::Url;
 
-use readable_readability::{Readability, Metadata};
-
+use readable_readability::{Metadata, Readability};
 
 // duplicate the Metadata struct so we can implement Deserialize
 #[derive(Deserialize)]
@@ -19,7 +18,6 @@ struct TestMetadata {
     pub description: Option<String>,
 }
 
-
 fn compare_metadata(actual: &Metadata, expected: &TestMetadata) {
     assert_eq!(actual.page_title, expected.page_title);
     assert_eq!(actual.article_title, expected.article_title);
@@ -27,7 +25,6 @@ fn compare_metadata(actual: &Metadata, expected: &TestMetadata) {
     assert_eq!(actual.byline, expected.byline);
     assert_eq!(actual.description, expected.description);
 }
-
 
 fn compare_trees(actual: &NodeRef, expected: &NodeRef) {
     compare_nodes(actual, expected);
@@ -43,13 +40,15 @@ fn compare_trees(actual: &NodeRef, expected: &NodeRef) {
             (None, None) => break,
             (None, Some(node)) => panic!("Expected {}", stringify_node(&node)),
             (Some(node), None) => panic!("Needless {}", stringify_node(&node)),
-            (Some(one), Some(two)) => compare_trees(&one, &two)
+            (Some(one), Some(two)) => compare_trees(&one, &two),
         }
     }
 }
 
 fn is_not_empty_text(node: &NodeRef) -> bool {
-    !node.as_text().map_or(false, |text| text.borrow().trim().is_empty())
+    !node
+        .as_text()
+        .map_or(false, |text| text.borrow().trim().is_empty())
 }
 
 fn compare_nodes(actual: &NodeRef, expected: &NodeRef) {
@@ -62,9 +61,13 @@ fn compare_nodes(actual: &NodeRef, expected: &NodeRef) {
             let expected_attributes = &expected_data.attributes.borrow().map;
 
             if actual_data.name != expected_data.name || actual_attributes != expected_attributes {
-                panic!("{} != {}", stringify_node(&actual), stringify_node(&expected));
+                panic!(
+                    "{} != {}",
+                    stringify_node(&actual),
+                    stringify_node(&expected)
+                );
             }
-        },
+        }
 
         (&Text(ref actual), &Text(ref expected)) => {
             let actual = actual.borrow();
@@ -76,14 +79,14 @@ fn compare_nodes(actual: &NodeRef, expected: &NodeRef) {
             if actual_words.ne(expected_words) {
                 panic!("TEXT: {} != {}", *actual, *expected);
             }
-        },
+        }
 
-        (&Comment(_), &Comment(_)) |
-        (&Doctype(_), &Doctype(_)) |
-        (&Document(_), &Document(_)) |
-        (&DocumentFragment, &DocumentFragment) => unimplemented!(),
+        (&Comment(_), &Comment(_))
+        | (&Doctype(_), &Doctype(_))
+        | (&Document(_), &Document(_))
+        | (&DocumentFragment, &DocumentFragment) => unimplemented!(),
 
-        _ => panic!("{} != {}", stringify_node(actual), stringify_node(expected))
+        _ => panic!("{} != {}", stringify_node(actual), stringify_node(expected)),
     };
 }
 
@@ -98,13 +101,15 @@ fn stringify_node(node: &NodeRef) -> String {
 
             for slice in string.split_terminator('>') {
                 pos += slice.len() + 1;
-                if pos >= LIMIT { break; }
+                if pos >= LIMIT {
+                    break;
+                }
             }
 
             string[..pos].to_owned()
-        },
+        }
         _ if string.len() > LIMIT => format!("{}...", &string[..LIMIT]),
-        _ => string
+        _ => string,
     }
 }
 
@@ -118,7 +123,7 @@ fn setup_logger() {
 macro_rules! include_sample_file {
     ($name:ident, $file:expr) => {
         include_str!(concat!("../samples/", stringify!($name), "/", $file))
-    }
+    };
 }
 
 macro_rules! test_sample {
@@ -135,8 +140,14 @@ macro_rules! test_sample {
                 .base_url(Url::parse("http://fakehost/test/page.html").unwrap())
                 .parse(SOURCE);
 
-            let expected_tree = kuchiki::parse_html().one(EXPECTED)
-                .select("body > *").unwrap().next().unwrap().as_node().clone();
+            let expected_tree = kuchiki::parse_html()
+                .one(EXPECTED)
+                .select("body > *")
+                .unwrap()
+                .next()
+                .unwrap()
+                .as_node()
+                .clone();
 
             compare_trees(&actual_tree, &expected_tree);
 


### PR DESCRIPTION
kuchiki is no longer maintained, but kuchikiki is a fork that's receiving updates.

This PR switches to kuchikiki as well as runs `cargo fmt` and addressed issues raised by `cargo clippy` in the first commit of two.